### PR TITLE
Allow default params

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ api.users(55).get(params: {foo: 'bar'})
 You can also set default params for all your requests on initialization:
 
 ```ruby
-api = Blanket::wrap("http://api.example.org", default_params: {access_token: 'my secret token'})
+api = Blanket::wrap("http://api.example.org", params: {access_token: 'my secret token'})
 ```
 
 ### Headers

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ api.users(55).get(params: {foo: 'bar'})
 # => "http://api.example.org/users/55?foo=bar"
 ```
 
+You can also set default params for all your requests on initialization:
+
+```ruby
+api = Blanket::wrap("http://api.example.org", default_params: {access_token: 'my secret token'})
+```
+
 ### Headers
 HTTP Headers are always useful when accessing an API, so Blanket makes it easy for you to specify them, either globally or on a per-request basis:
 

--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -21,7 +21,7 @@ module Blanket
 
     # Attribute accessor for  params that
     # should be applied to all requests
-    attr_accessor :default_params
+    attr_accessor :params
 
     # Attribute accessor for file extension that
     # should be appended to all requests
@@ -35,13 +35,13 @@ module Blanket
 
     # Wraps the base URL for an API
     # @param [String, Symbol] base_uri The root URL of the API you wish to wrap.
-    # @param [Hash] options An options hash with global values for :headers, :extension and :default_params
+    # @param [Hash] options An options hash with global values for :headers, :extension and :params
     # @return [Blanket] The Blanket object wrapping the API
     def initialize(base_uri, options={})
       @base_uri = base_uri
       @uri_parts = []
       @headers = options[:headers] || {}
-      @default_params = options[:default_params] || {}
+      @params = options[:params] || {}
       @extension = options[:extension]
     end
 
@@ -51,7 +51,7 @@ module Blanket
       Wrapper.new uri_from_parts([method, args.first]), {
         headers: @headers,
         extension: @extension,
-        default_params: @default_params
+        params: @params
       }
     end
 
@@ -88,7 +88,7 @@ module Blanket
     end
 
     def merged_params(params)
-      default_params.merge(params || {})
+      @params.merge(params || {})
     end
 
     def uri_from_parts(parts)

--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -1,5 +1,4 @@
 module Blanket
-  # The Wrapper class wraps an API
   class Wrapper
     class << self
       private
@@ -20,6 +19,10 @@ module Blanket
     # should be applied to all requests
     attr_accessor :headers
 
+    # Attribute accessor for  params that
+    # should be applied to all requests
+    attr_accessor :default_params
+
     # Attribute accessor for file extension that
     # should be appended to all requests
     attr_accessor :extension
@@ -32,12 +35,13 @@ module Blanket
 
     # Wraps the base URL for an API
     # @param [String, Symbol] base_uri The root URL of the API you wish to wrap.
-    # @param [Hash] options An options hash with global values for :headers and :extension
+    # @param [Hash] options An options hash with global values for :headers, :extension and :default_params
     # @return [Blanket] The Blanket object wrapping the API
     def initialize(base_uri, options={})
       @base_uri = base_uri
       @uri_parts = []
       @headers = options[:headers] || {}
+      @default_params = options[:default_params] || {}
       @extension = options[:extension]
     end
 
@@ -46,7 +50,8 @@ module Blanket
     def method_missing(method, *args, &block)
       Wrapper.new uri_from_parts([method, args.first]), {
         headers: @headers,
-        extension: @extension
+        extension: @extension,
+        default_params: @default_params
       }
     end
 
@@ -57,6 +62,7 @@ module Blanket
       end
 
       headers = merged_headers(options[:headers])
+      params = merged_params(options[:params])
       uri = uri_from_parts([id])
 
       if @extension
@@ -64,7 +70,7 @@ module Blanket
       end
 
       response = HTTParty.public_send(method, uri, {
-        query:   options[:params],
+        query:   params,
         headers: headers,
         body:    options[:body]
       }.reject { |_, value| value.nil? || value.empty? })
@@ -79,6 +85,10 @@ module Blanket
 
     def merged_headers(headers)
       @headers.merge(headers || {})
+    end
+
+    def merged_params(params)
+      default_params.merge(params || {})
     end
 
     def uri_from_parts(parts)

--- a/spec/blanket/wrapper_spec.rb
+++ b/spec/blanket/wrapper_spec.rb
@@ -143,6 +143,19 @@ describe "Blanket::Wrapper" do
         expect(HTTParty).to have_received(:get).with('http://api.example.org/users/55.xml', anything())
       end
     end
+
+    describe 'Body' do
+      before :each do
+        allow(HTTParty).to receive(:post) { StubbedResponse.new }
+      end
+
+      it 'allows setting the body for a request' do
+        api = Blanket::wrap("http://api.example.org")
+        api.users(55).post(body: { this_key: :this_value }.to_json)
+
+        expect(HTTParty).to have_received(:post).with('http://api.example.org/users/55', body: { this_key: :this_value }.to_json)
+      end
+    end
   end
 
   describe '#get' do

--- a/spec/blanket/wrapper_spec.rb
+++ b/spec/blanket/wrapper_spec.rb
@@ -116,7 +116,7 @@ describe "Blanket::Wrapper" do
       end
 
       it 'allows setting parameters globally' do
-        api = Blanket::wrap("http://api.example.org", default_params: {token: 'my secret token'})
+        api = Blanket::wrap("http://api.example.org", params: {token: 'my secret token'})
         api.users(55).get(params: {foo: 'bar'})
 
         expect(HTTParty).to have_received(:get).with('http://api.example.org/users/55', query: {token: 'my secret token', foo: 'bar'})

--- a/spec/blanket/wrapper_spec.rb
+++ b/spec/blanket/wrapper_spec.rb
@@ -114,6 +114,13 @@ describe "Blanket::Wrapper" do
 
         expect(HTTParty).to have_received(:get).with('http://api.example.org/users/55', query: {foo: 'bar'})
       end
+
+      it 'allows setting parameters globally' do
+        api = Blanket::wrap("http://api.example.org", default_params: {token: 'my secret token'})
+        api.users(55).get(params: {foo: 'bar'})
+
+        expect(HTTParty).to have_received(:get).with('http://api.example.org/users/55', query: {token: 'my secret token', foo: 'bar'})
+      end
     end
 
     describe 'URL Extension' do
@@ -134,19 +141,6 @@ describe "Blanket::Wrapper" do
         api.users(55).get
 
         expect(HTTParty).to have_received(:get).with('http://api.example.org/users/55.xml', anything())
-      end
-    end
-
-    describe 'Body' do
-      before :each do
-        allow(HTTParty).to receive(:post) { StubbedResponse.new }
-      end
-
-      it 'allows setting the body for a request' do
-        api = Blanket::wrap("http://api.example.org")
-        api.users(55).post(body: { this_key: :this_value }.to_json)
-
-        expect(HTTParty).to have_received(:post).with('http://api.example.org/users/55', body: { this_key: :this_value }.to_json)
       end
     end
   end


### PR DESCRIPTION
Allow default params to be globally set for all requests:

```ruby
Blanket.wrap('http://domain.com', default_params: { access_token: ´12345678´ })
```