### PR TITLE
Allow requests with body

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ repos.map(&:name)
 # => ["analytics-ios", "aztec", "fusebox", ...]
 ```
 
+### Request Body
+You can make requests with body using the `body` option:
+
+´´´ruby
+api = Blanket::wrap("http://api.example.org")
+api.messages.post(body: 'Hello')
+```
+
 ### Request Parameters
 Blanket supports appending parameters to your requests:
 

--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -7,7 +7,7 @@ module Blanket
       #   @method $1()
       #   Performs a $1 request on the wrapped URL
       #   @param [String, Symbol, Numeric] id The resource identifier to attach to the last part of the request
-      #   @param [Hash] options An options hash with values for :headers, :extension and :params
+      #   @param [Hash] options An options hash with values for :headers, :extension, :params and :body
       #   @return [Blanket::Response, Array] A wrapped Blanket::Response or an Array
       def add_action(action)
         define_method(action) do |id=nil, options={}|

--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -65,7 +65,8 @@ module Blanket
 
       response = HTTParty.public_send(method, uri, {
         query:   options[:params],
-        headers: headers
+        headers: headers,
+        body:    options[:body]
       }.reject { |_, value| value.nil? || value.empty? })
 
       if response.code <= 400

--- a/spec/blanket/wrapper_spec.rb
+++ b/spec/blanket/wrapper_spec.rb
@@ -136,6 +136,19 @@ describe "Blanket::Wrapper" do
         expect(HTTParty).to have_received(:get).with('http://api.example.org/users/55.xml', anything())
       end
     end
+
+    describe 'Body' do
+      before :each do
+        allow(HTTParty).to receive(:post) { StubbedResponse.new }
+      end
+
+      it 'allows setting the body for a request' do
+        api = Blanket::wrap("http://api.example.org")
+        api.users(55).post(body: { this_key: :this_value }.to_json)
+
+        expect(HTTParty).to have_received(:post).with('http://api.example.org/users/55', body: { this_key: :this_value }.to_json)
+      end
+    end
   end
 
   describe '#get' do


### PR DESCRIPTION
Allow to set the requet's body:

```ruby
api = Blanket.wrap('api.example.com')
api.users.post(body: { name: 'John Doe' }.to_json)
```