### PR TITLE
The response will always be an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,25 +92,7 @@ github.users.get('inf0rmer')
 ```
 
 ### Responses
-At the moment Blanket only accepts JSON responses. Every request returns a `Blanket::Response` instance, which parses the JSON internally and lets you access keys using dot syntax:
-
-```ruby
-user = github.users('inf0rmer').get
-
-user.login
-# => "inf0rmer"
-
-user.url
-# => "https://api.github.com/users/inf0rmer"
-
-# It even works on nested keys
-repo = github.repos('inf0rmer').get('blanket')
-
-repo.owner.login
-# => "inf0rmer"
-```
-
-If the response is an array, all `Enumerable` methods work as expected:
+At the moment Blanket only accepts JSON responses. Every request returns an array of `Blanket::Response`.
 
 ```ruby
 repos = github.users('inf0rmer').repos.get

--- a/lib/blanket/response.rb
+++ b/lib/blanket/response.rb
@@ -28,11 +28,7 @@ module Blanket
     end
 
     def payload_from_json(json)
-      parsed = [json].flatten.map do |item|
-        RecursiveOpenStruct.new item, recurse_over_arrays: true
-      end
-
-      (parsed.count == 1) ? parsed.first : parsed
+      [json].flatten.map { |item| RecursiveOpenStruct.new item, recurse_over_arrays: true }
     end
 
   end

--- a/spec/blanket/response_spec.rb
+++ b/spec/blanket/response_spec.rb
@@ -9,15 +9,15 @@ describe "Blanket::Response" do
       end
 
       it "can access a surface property from a json string as a method" do
-        expect(response.title).to eq("Something")
+        expect(response.first.title).to eq("Something")
       end
 
       it "can access a deep property from a json string as a method" do
-        expect(response.desc.someKey).to eq("someValue")
+        expect(response.first.desc.someKey).to eq("someValue")
       end
 
       it "can access a deep property in an array from a json string as a method" do
-        expect(response.main_item.values[0].quantity).to eq(1)
+        expect(response.first.main_item.values[0].quantity).to eq(1)
       end
     end
 


### PR DESCRIPTION
I think it's better that the response will be an array of ```Response``` instead of a ```Response```or an array of ```Response```, because the response is unified, in the last case is not.