### PR TITLE
Refactor `Blanket::Wrapper#uri_from_parts` to allow full paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ github.users('inf0rmer').repos
 
 The final `get` method performs a GET HTTP request. You can also use it to append a final part to your request, so you can write something like:
 
+As this magic works using `method_missingp`, you can `send` slashed uri parts to the wrapper and it will play nicely. This is especially usefull when APIs give you URLs:
+```ruby
+github.get('users/inf0rmer/repos')
+# or, if you don't wnat to perform the request yet, or have to append more parts to the uri
+github.send('users/inf0rmer').repos#.get
+```
+
 ```ruby
 github = Blanket.wrap("https://api.github.com")
 github.users.get('inf0rmer')

--- a/lib/blanket/version.rb
+++ b/lib/blanket/version.rb
@@ -1,4 +1,4 @@
 module Blanket
   # Current gem version
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -92,7 +92,7 @@ module Blanket
     end
 
     def uri_from_parts(parts)
-      ([@base_uri] + parts).compact.join('/')
+      File.join @base_uri, *parts.compact.map(&:to_s)
     end
   end
 end

--- a/spec/blanket/wrapper_spec.rb
+++ b/spec/blanket/wrapper_spec.rb
@@ -16,6 +16,14 @@ describe "Blanket::Wrapper" do
       expect(HTTParty).to have_received(:get).with("http://api.example.org/videos", anything())
     end
 
+    it 'allows full paths for uri construction' do
+      allow(HTTParty).to receive(:get) { StubbedResponse.new }
+
+      api.get('flexible/path')
+
+      expect(HTTParty).to have_received(:get).with("http://api.example.org/flexible/path", anything())
+    end
+
     describe "Response" do
       before :each do
         stub_request(:get, "http://api.example.org/users")


### PR DESCRIPTION
This tiny refactor allows you to send full paths to the wrapper:

```ruby
api = Blanket.wrap('https://api.github.com/')
=> #<Blanket::Wrapper:0x007fb04eeffd20
 @base_uri="https://api.github.com/",
 @extension=nil,
 @headers={},
 @params={},
 @uri_parts=[]>

api.get('users/inf0rmer/repos')
=> Response!

# or even/maybe, if you dont want to perform the request yet
api.send('users/inf0rmer/repos')
=> #<Blanket::Wrapper:0x007fb04a4fd3a8
 @base_uri="https://api.github.com/users/inf0rmer/repos",
 @extension=nil,
 @headers={},
 @params={},
 @uri_parts=[]>
```