### PR TITLE
Converts headers to a hash with stringified keys

### DIFF
--- a/lib/blanket/utils.rb
+++ b/lib/blanket/utils.rb
@@ -1,0 +1,5 @@
+module Blanket
+  def self.stringify_keys(hash)
+    hash.inject({}) {|memo,(k,v)| memo[k.to_s] = v; memo}
+  end
+end

--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -71,7 +71,7 @@ module Blanket
 
       response = HTTParty.public_send(method, uri, {
         query:   params,
-        headers: headers,
+        headers: stringify_keys(headers),
         body:    options[:body]
       }.reject { |_, value| value.nil? || value.empty? })
 
@@ -93,6 +93,10 @@ module Blanket
 
     def uri_from_parts(parts)
       File.join @base_uri, *parts.compact.map(&:to_s)
+    end
+
+    def stringify_keys(hash)
+      hash.inject({}) {|memo,(k,v)| memo[k.to_s] = v; memo}
     end
   end
 end

--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -1,3 +1,5 @@
+require_relative "utils"
+
 module Blanket
   class Wrapper
     class << self
@@ -61,7 +63,7 @@ module Blanket
         id = nil
       end
 
-      headers = merged_headers(options[:headers])
+      headers = Blanket.stringify_keys merged_headers(options[:headers])
       params = merged_params(options[:params])
       uri = uri_from_parts([id])
 
@@ -71,7 +73,7 @@ module Blanket
 
       response = HTTParty.public_send(method, uri, {
         query:   params,
-        headers: stringify_keys(headers),
+        headers: headers,
         body:    options[:body]
       }.reject { |_, value| value.nil? || value.empty? })
 
@@ -93,10 +95,6 @@ module Blanket
 
     def uri_from_parts(parts)
       File.join @base_uri, *parts.compact.map(&:to_s)
-    end
-
-    def stringify_keys(hash)
-      hash.inject({}) {|memo,(k,v)| memo[k.to_s] = v; memo}
     end
   end
 end

--- a/spec/blanket/wrapper_spec.rb
+++ b/spec/blanket/wrapper_spec.rb
@@ -101,14 +101,14 @@ describe "Blanket::Wrapper" do
       it 'allows sending headers in a request' do
         api.users(55).get(headers: {foo: 'bar'})
 
-        expect(HTTParty).to have_received(:get).with('http://api.example.org/users/55', headers: {foo: 'bar'})
+        expect(HTTParty).to have_received(:get).with('http://api.example.org/users/55', headers: {"foo" => "bar"})
       end
 
       it 'allows setting headers globally' do
         api = Blanket::wrap("http://api.example.org", headers: {token: 'my secret token'})
         api.users(55).get()
 
-        expect(HTTParty).to have_received(:get).with('http://api.example.org/users/55', headers: {token: 'my secret token'})
+        expect(HTTParty).to have_received(:get).with('http://api.example.org/users/55', headers: {"token" => "my secret token"})
       end
     end
 


### PR DESCRIPTION
`HTTParty` only takes hashes with stringified keys for headers, so this PR converts all headers hashes to their stringified versions