### PR TITLE
Simplest case of response_json.

### DIFF
--- a/lib/blanket/response.rb
+++ b/lib/blanket/response.rb
@@ -1,19 +1,20 @@
 require 'recursive-open-struct'
 require 'json'
-
 module Blanket
 
   # The Response class wraps HTTP responses
   class Response
-    # Attribute reader for the original JSON payload string
-    attr_reader :payload
+    # Attribute reader for the original JSON payload string and JSON payload
+    attr_reader :payload, :payload_json
 
     # A Blanket HTTP response wrapper.
     # @param [String] json_string A string containing data in the JSON format
     # @return [Blanket::Response] The wrapped Response object
     def initialize(json_string)
       json_string ||= "{}"
-      @payload = payload_from_json(JSON.parse(json_string))
+      json = JSON.parse(json_string)
+      @payload = payload_from_json(json)
+      @payload_json = json.to_json
     end
 
     private

--- a/spec/blanket/response_spec.rb
+++ b/spec/blanket/response_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'blanket/response'
 
-describe "Blanket::Response" do
+describe Blanket::Response do
   describe "Dynamic attribute accessors" do
     context "With single objects" do
       let :payload do
@@ -23,6 +23,10 @@ describe "Blanket::Response" do
 
       let :response do
         Blanket::Response.new(payload)
+      end
+
+      it "can access the payload json" do
+        expect(response.payload_json).to eq payload
       end
 
       it "can access a surface property from a json string as a method" do


### PR DESCRIPTION
References: http://jsonapi.org/format/#document-structure-top-level
and: https://github.com/inf0rmer/blanket/issues/21

Gives the user the option on which payload to work with. The JSON response is exposed via `response.payload_json`