### PR TITLE
Allow certain Kernel methods to be used

### DIFF
--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -15,6 +15,10 @@ module Blanket
           request(action, id, options)
         end
       end
+
+      def method_overrides
+        [:send]
+      end
     end
 
     # Attribute accessor for HTTP Headers that
@@ -55,6 +59,16 @@ module Blanket
         extension: @extension,
         params: @params
       }
+    end
+
+    method_overrides.each do |method_name|
+      define_method(method_name) do |argument|
+        Wrapper.new uri_from_parts([:method_name, args]), {
+          headers: @headers,
+          extension: @extension,
+          params: @params
+        }
+      end
     end
 
     def request(method, id=nil, options={})

--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -63,11 +63,10 @@ module Blanket
 
     method_overrides.each do |method_name|
       define_method(method_name) do |argument|
-        Wrapper.new uri_from_parts([:method_name, args]), {
+        Wrapper.new uri_from_parts([:method_name, argument]),
           headers: @headers,
           extension: @extension,
           params: @params
-        }
       end
     end
 

--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -63,10 +63,12 @@ module Blanket
 
     method_overrides.each do |method_name|
       define_method(method_name) do |argument|
-        Wrapper.new uri_from_parts([:method_name, argument]),
+        Wrapper.new(
+          uri_from_parts([:method_name, argument]),
           headers: @headers,
           extension: @extension,
           params: @params
+        )
       end
     end
 

--- a/spec/blanket/wrapper_spec.rb
+++ b/spec/blanket/wrapper_spec.rb
@@ -24,12 +24,13 @@ describe "Blanket::Wrapper" do
       expect(HTTParty).to have_received(:get).with("http://api.example.org/flexible/path", anything())
     end
 
-    it 'allows Kernel methods to be used' do
+    it "allows Kernel methods to be used" do
       allow(HTTParty).to receive(:get) { StubbedResponse.new }
 
-      api.get('flexible/send')
+      api.get("flexible/send")
 
-      expect(HTTParty).to have_received(:get).with("http://api.example.org/flexible/send", anything())
+      expect(HTTParty).to have_received(:get).
+        with("http://api.example.org/flexible/send", anything())
     end
 
     describe "Response" do

--- a/spec/blanket/wrapper_spec.rb
+++ b/spec/blanket/wrapper_spec.rb
@@ -24,6 +24,14 @@ describe "Blanket::Wrapper" do
       expect(HTTParty).to have_received(:get).with("http://api.example.org/flexible/path", anything())
     end
 
+    it 'allows Kernel methods to be used' do
+      allow(HTTParty).to receive(:get) { StubbedResponse.new }
+
+      api.get('flexible/send')
+
+      expect(HTTParty).to have_received(:get).with("http://api.example.org/flexible/send", anything())
+    end
+
     describe "Response" do
       before :each do
         stub_request(:get, "http://api.example.org/users")

--- a/spec/blanket/wrapper_spec.rb
+++ b/spec/blanket/wrapper_spec.rb
@@ -30,7 +30,7 @@ describe "Blanket::Wrapper" do
       api.get("flexible/send")
 
       expect(HTTParty).to have_received(:get).
-        with("http://api.example.org/flexible/send", anything())
+        with("http://api.example.org/flexible/send", anything)
     end
 
     describe "Response" do


### PR DESCRIPTION
Why:

* Some APIs have URL parts that match with ruby Kernel method names,
  making it impossible to catch with `method_missing`

This change addresses the need by:

* Allowing some specific method to be overriden to behave as expected