### PR TITLE
Enable a timeout to be set for the Blanket Wrapper so that all api requests will timeout in the given number of seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,28 @@ users_endpoint = api.users(55)
 users_endpoint.extension = :xml
 ```
 
+### Timeouts
+Some applications may require setting a timeout for your requests to ensure the request finishes within a given time
+or else an error will be raised. Simply pass your desired timeout to the .wrap options
+
+```ruby
+# All requests will raise an exception if they last longer than 15s
+api = Blanket.wrap("http://api.example.org", timeout: 15)
+
+begin
+  api.users(55).get
+rescue Timeout::Error => e
+  puts "Getting user 55 took too long!"
+end
+
+# An endpoint being built can override the timeout
+users_endpoint = api.user
+users_endpoint.timeout = 30
+
+# Individual request actions can override the timeout
+users_endpoint.get(55, timeout: 10)
+```
+
 ### Handling Exceptions
 
 Blanket will raise exceptions for HTTP errors encountered while making requests. Exception subclasses are raised for well known errors (404, 500, etc.) but for other status codes a default `Blanket::Exception` will be raised instead.

--- a/lib/blanket/response.rb
+++ b/lib/blanket/response.rb
@@ -27,5 +27,10 @@ module Blanket
     def payload
       @payload ||= JSON.parse(payload_json, object_class: OpenStruct)
     end
+
+    def to_s
+      @payload_json
+    end
+    alias inspect to_s
   end
 end

--- a/lib/blanket/version.rb
+++ b/lib/blanket/version.rb
@@ -1,4 +1,4 @@
 module Blanket
   # Current gem version
-  VERSION = "3.0.2"
+  VERSION = "3.1.0"
 end

--- a/lib/blanket/wrapper.rb
+++ b/lib/blanket/wrapper.rb
@@ -33,6 +33,10 @@ module Blanket
     # should be appended to all requests
     attr_accessor :extension
 
+    # Attribute accessor for timeout setting that
+    # should be applied to all requests
+    attr_accessor :timeout
+
     add_action :get
     add_action :post
     add_action :put
@@ -49,6 +53,7 @@ module Blanket
       @headers = options[:headers] || {}
       @params = options[:params] || {}
       @extension = options[:extension]
+      @extension = options[:timeout]
     end
 
     private
@@ -57,6 +62,7 @@ module Blanket
       Wrapper.new uri_from_parts([method, args.first]), {
         headers: @headers,
         extension: @extension,
+        timeout: @timeout,
         params: @params
       }
     end
@@ -67,6 +73,7 @@ module Blanket
           uri_from_parts([:method_name, argument]),
           headers: @headers,
           extension: @extension,
+          timeout: @timeout,
           params: @params
         )
       end
@@ -87,10 +94,11 @@ module Blanket
       end
 
       response = HTTParty.public_send(method, uri, {
+        timeout: options[:timeout] || timeout,
         query:   params,
         headers: headers,
         body:    options[:body]
-      }.reject { |_, value| value.nil? || value.empty? })
+      }.reject { |_, value| value.nil? || (value.respond_to?(:empty) && value.empty?) })
 
       if response.code < 400
         body = (response.respond_to? :body) ? response.body : nil


### PR DESCRIPTION


Bumps version to 3.1.0 at the same time.